### PR TITLE
feat: add sbrk and heap section for dynamic memory allocation

### DIFF
--- a/app/link.ld
+++ b/app/link.ld
@@ -37,6 +37,13 @@ SECTIONS
         _end = .;
     } > dmem
 
+    .heap : {
+        . = ALIGN(16);
+        _heap_start = .;
+        . = ORIGIN(dmem) + LENGTH(dmem);
+        _heap_end = .;
+    } > dmem
+
     /DISCARD/ : {
         *(.debug*)
     }
@@ -44,3 +51,6 @@ SECTIONS
 
 PROVIDE(_tohost = 0x80000000);
 PROVIDE(_fstack = ORIGIN(dmem) + LENGTH(dmem));
+
+PROVIDE(__heap_start = _heap_start);
+PROVIDE(__heap_end = _heap_end);

--- a/app/sbrk.c
+++ b/app/sbrk.c
@@ -1,0 +1,35 @@
+/* CFU Proving Ground since 2025-02    Copyright(c) 2025 Archlab. Science Tokyo /
+/ Released under the MIT license https://opensource.org/licenses/mit           */
+
+#include "sbrk.h"
+
+extern char _heap_start;
+extern char _heap_end;
+
+static char *heap_ptr = 0;
+
+void *_sbrk(int incr)
+{
+    char *prev_heap_ptr;
+
+    // Initialize heap pointer on first call
+    if (heap_ptr == 0) {
+        heap_ptr = &_heap_start;
+    }
+
+    prev_heap_ptr = heap_ptr;
+
+    if (heap_ptr + incr > &_heap_end) {
+        // Out of memory
+        return (void *) -1;
+    }
+
+    if (heap_ptr + incr < &_heap_start) {
+        // Cannot shrink below start of heap
+        return (void *) -1;
+    }
+
+    heap_ptr += incr;
+
+    return prev_heap_ptr;
+}

--- a/app/sbrk.h
+++ b/app/sbrk.h
@@ -1,0 +1,9 @@
+/* CFU Proving Ground since 2025-02    Copyright(c) 2025 Archlab. Science Tokyo /
+/ Released under the MIT license https://opensource.org/licenses/mit           */
+
+#ifndef SBRK_H
+#define SBRK_H
+
+void *_sbrk(int incr);
+
+#endif


### PR DESCRIPTION
This PR enables standard C lib dynamic memory allocation, such as `malloc`, `free` and `calloc`